### PR TITLE
Re-order overloads and get rid of modules in TypeScript types.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "hot-shots",
-  "version": "6.1.1",
+  "name": "@binaris/hot-shots",
+  "version": "6.1.2-rc.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -23,6 +23,11 @@
         "esutils": "^2.0.2",
         "js-tokens": "^4.0.0"
       }
+    },
+    "@types/node": {
+      "version": "11.10.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.10.4.tgz",
+      "integrity": "sha512-wa09itaLE8L705aXd8F80jnFpxz3Y1/KRHfKsYL2bPc0XF+wEWu8sR9n5bmeu8Ba1N9z2GRNzm/YdHcghLkLKg=="
     },
     "acorn": {
       "version": "6.0.4",
@@ -782,6 +787,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -1964,7 +1970,8 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "loose-envify": {
           "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
-  "name": "hot-shots",
-  "description": "Node.js client for StatsD, DogStatsD, and Telegraf",
-  "version": "6.1.1",
+  "name": "@binaris/hot-shots",
+  "description": "Node.js client for StatsD, DogStatsD, and Telegraf (better types in Binaris)",
+  "version": "6.1.2-rc.3",
   "author": "Steve Ivy",
   "types": "./types.d.ts",
   "contributors": [
     "Russ Bradberry <rbradberry@gmail.com>",
-    "Brian Deitte <bdeitte@gmail.com>"
+    "Brian Deitte <bdeitte@gmail.com>",
+    "Ariel Shaqed (Scolnicov) <ariels@binaris.com>"
   ],
   "keywords": [
     "statsd",
@@ -34,7 +35,9 @@
     "lint": "eslint lib/**.js test/**.js",
     "pretest": "npm run lint"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@types/node": "^11.10.4"
+  },
   "devDependencies": {
     "eslint": "5.9.x",
     "mocha": "4.x",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@binaris/hot-shots",
   "description": "Node.js client for StatsD, DogStatsD, and Telegraf (better types in Binaris)",
-  "version": "6.1.2-rc.3",
+  "version": "6.1.2",
   "author": "Steve Ivy",
   "types": "./types.d.ts",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -35,9 +35,6 @@
     "lint": "eslint lib/**.js test/**.js",
     "pretest": "npm run lint"
   },
-  "dependencies": {
-    "@types/node": "^11.10.4"
-  },
   "devDependencies": {
     "eslint": "5.9.x",
     "mocha": "4.x",

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,134 +1,132 @@
 import dgram = require("dgram");
 
-declare module "hot-shots" {
-  export type Tags = { [key: string]: string } | string[];
-  export interface ClientOptions {
-    bufferFlushInterval?: number;
-    bufferHolder?: { buffer: string };
-    cacheDns?: boolean;
-    errorHandler?: (err: Error) => void;
-    globalTags?: Tags;
-    globalize?: boolean;
-    host?: string;
-    isChild?: boolean;
-    maxBufferSize?: number;
-    mock?: boolean;
-    port?: number;
-    prefix?: string;
-    sampleRate?: number;
-    socket?: dgram.Socket;
-    suffix?: string;
-    telegraf?: boolean;
-    useDefaultRoute?: boolean;
-  }
-
-  export interface ChildClientOptions {
-    globalTags?: Tags;
-    prefix?: string;
-    suffix?: string;
-  }
-
-  export interface CheckOptions {
-    date_happened?: Date;
-    hostname?: string;
-    message?: string;
-  }
-
-  export interface DatadogChecks {
-    OK: 0;
-    WARNING: 1;
-    CRITICAL: 2;
-    UNKNOWN: 3;
-  }
-
-  type unionFromInterfaceValues4<
-    T,
-    K1 extends keyof T,
-    K2 extends keyof T,
-    K3 extends keyof T,
-    K4 extends keyof T,
-  > = T[K1] | T[K2] | T[K3] | T[K4];
-
-  export type DatadogChecksValues = unionFromInterfaceValues4<DatadogChecks, "OK", "WARNING", "CRITICAL", "UNKNOWN">;
-
-  export interface EventOptions {
-    aggregation_key?: string;
-    alert_type?: "info" | "warning" | "success" | "error";
-    date_happened?: Date;
-    hostname?: string;
-    priority?: "low" | "normal";
-    source_type_name?: string;
-  }
-
-  export type StatsCb = (error: Error | undefined, bytes: any) => void;
-
-  export class StatsD {
-    constructor(options?: ClientOptions);
-    childClient(options?: ChildClientOptions): StatsD;
-
-    increment(stat: string, tags?: Tags): void;
-    increment(stat: string | string[], value: number, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
-    increment(stat: string | string[], value: number, tags?: Tags, callback?: StatsCb): void;
-    increment(stat: string | string[], value: number, callback?: StatsCb): void;
-    increment(stat: string | string[], value: number, sampleRate?: number, callback?: StatsCb): void;
-
-    decrement(stat: string): void;
-    decrement(stat: string | string[], value: number, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
-    decrement(stat: string | string[], value: number, tags?: Tags, callback?: StatsCb): void;
-    decrement(stat: string | string[], value: number, callback?: StatsCb): void;
-    decrement(stat: string | string[], value: number, sampleRate?: number, callback?: StatsCb): void;
-
-    timing(stat: string | string[], value: number, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
-    timing(stat: string | string[], value: number, tags?: Tags, callback?: StatsCb): void;
-    timing(stat: string | string[], value: number, callback?: StatsCb): void;
-    timing(stat: string | string[], value: number, sampleRate?: number, callback?: StatsCb): void;
-
-    timer(func: (...args: any[]) => any, stat: string | string[], sampleRate?: number, tags?: Tags, callback?: StatsCb): (...args: any[]) => any;
-    timer(func: (...args: any[]) => any, stat: string | string[], tags?: Tags, callback?: StatsCb): (...args: any[]) => any;
-    timer(func: (...args: any[]) => any, stat: string | string[], callback?: StatsCb): (...args: any[]) => any;
-    timer(func: (...args: any[]) => any, stat: string | string[], sampleRate?: number, callback?: StatsCb): (...args: any[]) => any;
-
-    asyncTimer<T>(func: (...args: any[]) => Promise<T>, stat: string | string[], sampleRate?: number, tags?: Tags, callback?: StatsCb): (...args: any[]) => Promise<T>;
-    asyncTimer<T>(func: (...args: any[]) => Promise<T>, stat: string | string[], tags?: Tags, callback?: StatsCb): (...args: any[]) => Promise<T>;
-    asyncTimer<T>(func: (...args: any[]) => Promise<T>, stat: string | string[], callback?: StatsCb): (...args: any[]) => Promise<T>;
-    asyncTimer<T>(func: (...args: any[]) => Promise<T>, stat: string | string[], sampleRate?: number, callback?: StatsCb): (...args: any[]) => Promise<T>;
-
-    histogram(stat: string | string[], value: number, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
-    histogram(stat: string | string[], value: number, tags?: Tags, callback?: StatsCb): void;
-    histogram(stat: string | string[], value: number, callback?: StatsCb): void;
-    histogram(stat: string | string[], value: number, sampleRate?: number, callback?: StatsCb): void;
-
-    distribution(stat: string | string[], value: number, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
-    distribution(stat: string | string[], value: number, tags?: Tags, callback?: StatsCb): void;
-    distribution(stat: string | string[], value: number, callback?: StatsCb): void;
-    distribution(stat: string | string[], value: number, sampleRate?: number, callback?: StatsCb): void;
-
-    gauge(stat: string | string[], value: number, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
-    gauge(stat: string | string[], value: number, tags?: Tags, callback?: StatsCb): void;
-    gauge(stat: string | string[], value: number, callback?: StatsCb): void;
-    gauge(stat: string | string[], value: number, sampleRate?: number, callback?: StatsCb): void;
-
-    set(stat: string | string[], value: number, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
-    set(stat: string | string[], value: number, tags?: Tags, callback?: StatsCb): void;
-    set(stat: string | string[], value: number, callback?: StatsCb): void;
-    set(stat: string | string[], value: number, sampleRate?: number, callback?: StatsCb): void;
-
-    unique(stat: string | string[], value: number, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
-    unique(stat: string | string[], value: number, tags?: Tags, callback?: StatsCb): void;
-    unique(stat: string | string[], value: number, callback?: StatsCb): void;
-    unique(stat: string | string[], value: number, sampleRate?: number, callback?: StatsCb): void;
-
-    close(callback: (error?: Error) => void): void;
-
-    event(title: string, text?: string, options?: EventOptions, tags?: Tags, callback?: StatsCb): void;
-    event(title: string, text?: string, options?: EventOptions, callback?: StatsCb): void;
-    check(name: string, status: DatadogChecksValues, options?: CheckOptions, tags?: Tags, callback?: StatsCb): void;
-
-    public CHECKS: DatadogChecks;
-    public mockBuffer?: string[];
-    public socket: dgram.Socket;
-  }
+export type Tags = { [key: string]: string } | string[];
+export interface ClientOptions {
+  bufferFlushInterval?: number;
+  bufferHolder?: { buffer: string };
+  cacheDns?: boolean;
+  errorHandler?: (err: Error) => void;
+  globalTags?: Tags;
+  globalize?: boolean;
+  host?: string;
+  isChild?: boolean;
+  maxBufferSize?: number;
+  mock?: boolean;
+  port?: number;
+  prefix?: string;
+  sampleRate?: number;
+  socket?: dgram.Socket;
+  suffix?: string;
+  telegraf?: boolean;
+  useDefaultRoute?: boolean;
 }
 
-declare const StatsDClient: StatsD;
-export default StatsDClient;
+export interface ChildClientOptions {
+  globalTags?: Tags;
+  prefix?: string;
+  suffix?: string;
+}
+
+export interface CheckOptions {
+  date_happened?: Date;
+  hostname?: string;
+  message?: string;
+}
+
+export interface DatadogChecks {
+  OK: 0;
+  WARNING: 1;
+  CRITICAL: 2;
+  UNKNOWN: 3;
+}
+
+type unionFromInterfaceValues4<
+  T,
+K1 extends keyof T,
+K2 extends keyof T,
+K3 extends keyof T,
+K4 extends keyof T,
+  > = T[K1] | T[K2] | T[K3] | T[K4];
+
+export type DatadogChecksValues = unionFromInterfaceValues4<DatadogChecks, "OK", "WARNING", "CRITICAL", "UNKNOWN">;
+
+export interface EventOptions {
+  aggregation_key?: string;
+  alert_type?: "info" | "warning" | "success" | "error";
+  date_happened?: Date;
+  hostname?: string;
+  priority?: "low" | "normal";
+  source_type_name?: string;
+}
+
+export type StatsCb = (error: Error | undefined, bytes: any) => void;
+
+export class StatsD {
+  constructor(options?: ClientOptions);
+  childClient(options?: ChildClientOptions): StatsD;
+
+  increment(stat: string, tags?: Tags): void;
+  increment(stat: string | string[], value: number, callback?: StatsCb): void;
+  increment(stat: string | string[], value: number, tags?: Tags, callback?: StatsCb): void;
+  increment(stat: string | string[], value: number, sampleRate?: number, callback?: StatsCb): void;
+  increment(stat: string | string[], value: number, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
+
+  decrement(stat: string): void;
+  decrement(stat: string | string[], value: number, callback?: StatsCb): void;
+  decrement(stat: string | string[], value: number, tags?: Tags, callback?: StatsCb): void;
+  decrement(stat: string | string[], value: number, sampleRate?: number, callback?: StatsCb): void;
+  decrement(stat: string | string[], value: number, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
+
+  timing(stat: string | string[], value: number, callback?: StatsCb): void;
+  timing(stat: string | string[], value: number, tags?: Tags, callback?: StatsCb): void;
+  timing(stat: string | string[], value: number, sampleRate?: number, callback?: StatsCb): void;
+  timing(stat: string | string[], value: number, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
+
+  timer(func: (...args: any[]) => any, stat: string | string[], callback?: StatsCb): (...args: any[]) => any;
+  timer(func: (...args: any[]) => any, stat: string | string[], tags?: Tags, callback?: StatsCb): (...args: any[]) => any;
+  timer(func: (...args: any[]) => any, stat: string | string[], sampleRate?: number, callback?: StatsCb): (...args: any[]) => any;
+  timer(func: (...args: any[]) => any, stat: string | string[], sampleRate?: number, tags?: Tags, callback?: StatsCb): (...args: any[]) => any;
+
+  asyncTimer<T>(func: (...args: any[]) => Promise<T>, stat: string | string[], callback?: StatsCb): (...args: any[]) => Promise<T>;
+  asyncTimer<T>(func: (...args: any[]) => Promise<T>, stat: string | string[], sampleRate?: number, callback?: StatsCb): (...args: any[]) => Promise<T>;
+  asyncTimer<T>(func: (...args: any[]) => Promise<T>, stat: string | string[], tags?: Tags, callback?: StatsCb): (...args: any[]) => Promise<T>;
+  asyncTimer<T>(func: (...args: any[]) => Promise<T>, stat: string | string[], sampleRate?: number, tags?: Tags, callback?: StatsCb): (...args: any[]) => Promise<T>;
+
+  histogram(stat: string | string[], value: number, callback?: StatsCb): void;
+  histogram(stat: string | string[], value: number, tags?: Tags, callback?: StatsCb): void;
+  histogram(stat: string | string[], value: number, sampleRate?: number, callback?: StatsCb): void;
+  histogram(stat: string | string[], value: number, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
+
+  distribution(stat: string | string[], value: number, callback?: StatsCb): void;
+  distribution(stat: string | string[], value: number, tags?: Tags, callback?: StatsCb): void;
+  distribution(stat: string | string[], value: number, sampleRate?: number, callback?: StatsCb): void;
+  distribution(stat: string | string[], value: number, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
+
+  gauge(stat: string | string[], value: number, callback?: StatsCb): void;
+  gauge(stat: string | string[], value: number, tags?: Tags, callback?: StatsCb): void;
+  gauge(stat: string | string[], value: number, sampleRate?: number, callback?: StatsCb): void;
+  gauge(stat: string | string[], value: number, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
+
+  set(stat: string | string[], value: number, callback?: StatsCb): void;
+  set(stat: string | string[], value: number, tags?: Tags, callback?: StatsCb): void;
+  set(stat: string | string[], value: number, sampleRate?: number, callback?: StatsCb): void;
+  set(stat: string | string[], value: number, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
+
+  unique(stat: string | string[], value: number, callback?: StatsCb): void;
+  unique(stat: string | string[], value: number, tags?: Tags, callback?: StatsCb): void;
+  unique(stat: string | string[], value: number, sampleRate?: number, callback?: StatsCb): void;
+  unique(stat: string | string[], value: number, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
+
+  close(callback: (error?: Error) => void): void;
+
+  event(title: string, text?: string, options?: EventOptions, callback?: StatsCb): void;
+  event(title: string, text?: string, options?: EventOptions, tags?: Tags, callback?: StatsCb): void;
+
+  check(name: string, status: DatadogChecksValues, options?: CheckOptions, tags?: Tags, callback?: StatsCb): void;
+
+  public CHECKS: DatadogChecks;
+  public mockBuffer?: string[];
+  public socket: dgram.Socket;
+}
+
+export default StatsD;


### PR DESCRIPTION
Overloads should generally be ordered in *increasing* number of
optional args: the first matching overload is (always) selected.

Also get rid of the (single) "hot-shots" module, it needlessly
complicates type definitions.